### PR TITLE
Fix trackIndex out of bounds during shuffle

### DIFF
--- a/frontend/playlist_player.ts
+++ b/frontend/playlist_player.ts
@@ -108,7 +108,7 @@ class PlaylistData {
         let i = 0;
         // This reads weird but essentially its false by default so we check against it.
         while (this.tracks[trackIndex].played && !(i > this.tracks.length)) {
-          trackIndex = Math.floor(Math.random() * this.tracks.length - 1);
+          trackIndex = Math.floor(Math.random() * (this.tracks.length - 1));
           i++;
       }
     } else if (this.loop_all && this.trackIndex == this.tracks.length - 1) {

--- a/frontend/playlist_player.ts
+++ b/frontend/playlist_player.ts
@@ -107,7 +107,7 @@ class PlaylistData {
     if (this.shuffle) {
         let i = 0;
         // This reads weird but essentially its false by default so we check against it.
-        while (this.tracks[trackIndex].played && !(i > this.tracks.length)) {
+        while (this.tracks[trackIndex].played && i <= this.tracks.length) {
           trackIndex = Math.floor(Math.random() * (this.tracks.length - 1));
           i++;
       }


### PR DESCRIPTION
This should fix an error with the trackIndex sometimes being set to -1 during shuffling, which causes an exception (`VIDEOJS: ERROR: TypeError: this.tracks[trackIndex] is undefined`) and terminates the shuffle.

The issue is caused by `Math.random()` returning 0 or a value small enough that the formula returns a result smaller than 0 (x=1/tracks.length), which the floor function turns into -1.